### PR TITLE
Improve cursor performance

### DIFF
--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -48,9 +48,9 @@ abstract class Cursor
         $nextPos = $pos + 1;
 
         if (
-            $char === "\r" &&
-            $nextPos < $this->length &&
-            $this->chars[$nextPos] === "\n"
+            $char === "\r"
+            && $nextPos < $this->length
+            && $this->chars[$nextPos] === "\n"
         ) {
             return "\n";
         }

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -34,6 +34,11 @@ abstract class Cursor
         return $this->peekOffset;
     }
 
+    private function substr($start, $length = 1): string
+    {
+        return implode('', array_slice($this->buffer, $start, $length));
+    }
+
     private function charFromIndex(int $offset = 0): ?string
     {
         $pos = $this->index + $offset;
@@ -76,10 +81,6 @@ abstract class Cursor
 
             $this->incrementIndex($isClRf ? 2 : 1);
         }
-    }
-
-    private function substr($start, $length = 1){
-        return implode('', array_slice($this->buffer, $start, $length));
     }
 
     public function peek(int $chars = 1): ?string

--- a/src/Parser/Cursor.php
+++ b/src/Parser/Cursor.php
@@ -34,7 +34,7 @@ abstract class Cursor
         return $this->peekOffset;
     }
 
-    private function substr($start, $length = 1): string
+    private function substr(int $start, int $length = 1): string
     {
         return implode('', array_slice($this->buffer, $start, $length));
     }


### PR DESCRIPTION
1. Updated composer deps
2. mb_substr replaced to mb_str_split
3. Node version updated to actual
4. phpunit.xml.dist updated to actual

Parser bench before:

```
+------+-------------+-------------------------+-----+------+------------+---------------+--------------+----------------+
| iter | benchmark   | subject                 | set | revs | mem_peak   | time_avg      | comp_z_value | comp_deviation |
+------+-------------+-------------------------+-----+------+------------+---------------+--------------+----------------+
| 0    | ParserBench | benchFirefoxPreferences |     | 10   | 4,622,672b | 368,879.500μs | -0.65σ       | -0.88%         |
| 1    | ParserBench | benchFirefoxPreferences |     | 10   | 4,622,672b | 366,646.000μs | -1.09σ       | -1.48%         |
| 2    | ParserBench | benchFirefoxPreferences |     | 10   | 4,622,672b | 370,244.100μs | -0.38σ       | -0.51%         |
| 3    | ParserBench | benchFirefoxPreferences |     | 10   | 4,622,672b | 373,931.200μs | +0.35σ       | +0.48%         |
| 4    | ParserBench | benchFirefoxPreferences |     | 10   | 4,622,672b | 381,093.800μs | +1.77σ       | +2.40%         |
+------+-------------+-------------------------+-----+------+------------+---------------+--------------+----------------+
```

After: 

```
+------+-------------+-------------------------+-----+------+------------+--------------+--------------+----------------+
| iter | benchmark   | subject                 | set | revs | mem_peak   | time_avg     | comp_z_value | comp_deviation |
+------+-------------+-------------------------+-----+------+------------+--------------+--------------+----------------+
| 0    | ParserBench | benchFirefoxPreferences |     | 10   | 8,330,040b | 23,806.100μs | -0.93σ       | -1.03%         |
| 1    | ParserBench | benchFirefoxPreferences |     | 10   | 8,330,040b | 23,670.400μs | -1.43σ       | -1.60%         |
| 2    | ParserBench | benchFirefoxPreferences |     | 10   | 8,330,040b | 24,274.300μs | +0.82σ       | +0.91%         |
| 3    | ParserBench | benchFirefoxPreferences |     | 10   | 8,330,040b | 24,171.900μs | +0.44σ       | +0.49%         |
| 4    | ParserBench | benchFirefoxPreferences |     | 10   | 8,330,040b | 24,349.000μs | +1.10σ       | +1.22%         |
+------+-------------+-------------------------+-----+------+------------+--------------+--------------+----------------+
```

Its looks like we got memory usage x2, but adwantage in speed is more than 15 times. And on bigger files it becomes more significant. 204KB file in example:

Old:

```
+------+-------------+-------------------------+-----+------+------------+-----------------+--------------+----------------+
| iter | benchmark   | subject                 | set | revs | mem_peak   | time_avg        | comp_z_value | comp_deviation |
+------+-------------+-------------------------+-----+------+------------+-----------------+--------------+----------------+
| 0    | ParserBench | benchFirefoxPreferences |     | 10   | 7,377,128b | 4,960,811.400μs | -1.53σ       | -1.07%         |
| 1    | ParserBench | benchFirefoxPreferences |     | 10   | 7,377,128b | 4,997,625.000μs | -0.48σ       | -0.34%         |
| 2    | ParserBench | benchFirefoxPreferences |     | 10   | 7,377,128b | 5,062,494.200μs | +1.37σ       | +0.96%         |
| 3    | ParserBench | benchFirefoxPreferences |     | 10   | 7,377,128b | 5,011,520.200μs | -0.09σ       | -0.06%         |
| 4    | ParserBench | benchFirefoxPreferences |     | 10   | 7,377,128b | 5,040,271.900μs | +0.73σ       | +0.51%         |
+------+-------------+-------------------------+-----+------+------------+-----------------+--------------+----------------+
```

New:

```
+------+-------------+-------------------------+-----+------+-------------+--------------+--------------+----------------+
| iter | benchmark   | subject                 | set | revs | mem_peak    | time_avg     | comp_z_value | comp_deviation |
+------+-------------+-------------------------+-----+------+-------------+--------------+--------------+----------------+
| 0    | ParserBench | benchFirefoxPreferences |     | 10   | 20,932,768b | 84,057.700μs | +0.94σ       | +1.66%         |
| 1    | ParserBench | benchFirefoxPreferences |     | 10   | 20,932,768b | 84,720.500μs | +1.39σ       | +2.46%         |
| 2    | ParserBench | benchFirefoxPreferences |     | 10   | 20,932,768b | 82,237.600μs | -0.31σ       | -0.55%         |
| 3    | ParserBench | benchFirefoxPreferences |     | 10   | 20,932,768b | 80,988.300μs | -1.16σ       | -2.06%         |
| 4    | ParserBench | benchFirefoxPreferences |     | 10   | 20,932,768b | 81,439.900μs | -0.86σ       | -1.51%         |
+------+-------------+-------------------------+-----+------+-------------+--------------+--------------+----------------+
```

Execution time reduced by more than 60 times.  And in our project its not biggest file.

All tests still passed
