### PR TITLE
Fix rounding issues

### DIFF
--- a/src/Formatters/Number/NumberFormatter.php
+++ b/src/Formatters/Number/NumberFormatter.php
@@ -162,7 +162,11 @@ final class NumberFormatter
             $trimmed++;
         }
 
-        return [$int, substr($paddingZeros . $trimmed, -$maximumFractionDigits)];
+        if (strlen((string) $trimmed) > $maximumFractionDigits) {
+            return [(string) ++$int, ''];
+        }
+
+        return [$int, rtrim($paddingZeros . $trimmed, '0')];
     }
 
     private function applyMaximumSignificantDigits(Options $o, string $int): string

--- a/tests/Formatters/Number/DecimalFormatterTest.php
+++ b/tests/Formatters/Number/DecimalFormatterTest.php
@@ -54,6 +54,7 @@ final class DecimalFormatterTest extends NumberFormatterTestCase
             [45.67, ['maximumSignificantDigits' => 2]],
             [5962399.87, ['maximumSignificantDigits' => 3]],
             [46538.069971871, ['maxFractionDigits' => 4]],
+            [46538.999971871, ['maxFractionDigits' => 4]],
         ] as $case) {
             foreach (self::provideLocales() as $locale) {
                 yield [$locale, ...$case];


### PR DESCRIPTION
The issue:

```
= 5962399.87
59 623 910
59 623 900
59 624 000
59 620 000

= 5962390.87
5 962 391
5 962 390
5 962 400
5 962 000

= 5962990.87
5 962 990
59 621 000
5 963 000

= 46538.069971871
46 538,06910
46 538,06997
```

Code to reproduce:
```php
    private NumberFormatter $numberFormatter;

    public function index(): void
    {
        $this->numberFormatter = new NumberFormatter('ru');
        echo "= 5962399.87\n";
        echo $this->maxSignificantDigits(5962399.87, 0);
        echo "\n";
        echo $this->maxSignificantDigits(5962399.87, 1);
        echo "\n";
        echo $this->maxSignificantDigits(5962399.87, 2);
        echo "\n";
        echo $this->maxSignificantDigits(5962399.87, 3);
        echo "\n";
        echo "\n= 5962390.87\n";
        echo $this->maxSignificantDigits(5962390.87, 0);
        echo "\n";
        echo $this->maxSignificantDigits(5962390.87, 1);
        echo "\n";
        echo $this->maxSignificantDigits(5962390.87, 2);
        echo "\n";
        echo $this->maxSignificantDigits(5962390.87, 3);
        echo "\n";
        echo "\n= 5962990.87\n";
        echo $this->maxSignificantDigits(5962990.87, 1);
        echo "\n";
        echo $this->maxSignificantDigits(5962990.87, 2);
        echo "\n";
        echo $this->maxSignificantDigits(5962990.87, 3);
        echo "\n";
        echo "\n= 46538.069971871\n";
        echo $this->maxFractionDigits(46538.069971871, 4);
        echo "\n";
        echo $this->maxFractionDigits(46538.069971871, 5);
    }

    private function maxSignificantDigits(float $number, int $cut): string
    {
        return $this->fluentNumber($number, ['maximumSignificantDigits' => strlen(round($number)) - $cut]);
    }

    private function maxFractionDigits(float $number, int $length): string
    {
        return $this->fluentNumber($number, ['maximumFractionDigits' => $length]);
    }

    private function fluentNumber(float $number, array $opts = []): string
    {
        $fluent_number = new FluentNumber($number);
        $fluent_number->setOptions($opts);
        return $this->numberFormatter->format($number, $fluent_number->options());
    }
```